### PR TITLE
Signature registry & mappings

### DIFF
--- a/SignatureReg.sol
+++ b/SignatureReg.sol
@@ -29,9 +29,6 @@ contract SignatureReg is Owned {
   // mapping of signatures to entries
   mapping (bytes4 => Entry) public entries;
 
-  // a list of all available signatures
-  bytes4[] public signatures;
-
   // the total count of registered signatures
   uint public totalSignatures = 0;
 

--- a/SignatureReg.sol
+++ b/SignatureReg.sol
@@ -18,28 +18,20 @@ contract Owned {
 }
 
 contract SignatureReg is Owned {
-  // a signature structure, storing the method name & owner
-  //    method - a human-readable method in the form of "getMethod(bytes32)"
-  //    owner  - the person registering the type
-  struct Entry {
-    string method;
-    address owner;
-  }
-
   // mapping of signatures to entries
-  mapping (bytes4 => Entry) public entries;
+  mapping (bytes4 => string) public entries;
 
   // the total count of registered signatures
   uint public totalSignatures = 0;
 
   // allow only new calls to go in
   modifier when_unregistered(bytes4 _signature) {
-    if (entries[_signature].owner != 0) return;
+    if (bytes(entries[_signature]).length != 0) return;
     _;
   }
 
   // dispatched when a new signature is registered
-  event Registered(address indexed owner, bytes4 indexed signature, string method);
+  event Registered(address indexed creator, bytes4 indexed signature, string method);
 
   // constructor with self-registration
   function SignatureReg() {
@@ -53,17 +45,10 @@ contract SignatureReg is Owned {
 
   // internal register function, signature => method
   function _register(bytes4 _signature, string _method) internal when_unregistered(_signature) returns (bool) {
-    entries[_signature] = Entry(_method, msg.sender);
+    entries[_signature] = _method;
     totalSignatures = totalSignatures + 1;
     Registered(msg.sender, _signature, _method);
     return true;
-  }
-
-  // returns a specific method
-  function get(bytes4 _signature) constant returns (string method, address owner) {
-    Entry entry = entries[_signature];
-    method = entry.method;
-    owner = entry.owner;
   }
 
   // in the case of any extra funds

--- a/SignatureReg.sol
+++ b/SignatureReg.sol
@@ -1,0 +1,80 @@
+//! A decentralised registry of 4-bytes signatures => method mappings
+//! By Parity Team (Ethcore), 2016.
+//! Released under the Apache Licence 2.
+
+pragma solidity ^0.4.1;
+
+contract Owned {
+  modifier only_owner {
+    if (msg.sender != owner) return;
+    _;
+  }
+
+  event NewOwner(address indexed old, address indexed current);
+
+  function setOwner(address _new) only_owner { NewOwner(owner, _new); owner = _new; }
+
+  address public owner = msg.sender;
+}
+
+contract SignatureReg is Owned {
+  // a signature structure, storing the method name & owner
+  //    method - a human-readable method in the form of "getMethod(bytes32)"
+  //    owner  - the person registering the type
+  struct Entry {
+    string method;
+    address owner;
+  }
+
+  // mapping of signatures to entries
+  mapping (bytes4 => Entry) public entries;
+
+  // a list of all available signatures
+  bytes4[] public signatures;
+
+  // the total count of registered signatures
+  uint public totalSignatures = 0;
+
+  // allow only new calls to go in
+  modifier when_unregistered(bytes4 _signature) {
+    if (entries[_signature].owner != 0) return;
+    _;
+  }
+
+  // dispatched when a new signature => method is registered
+  event Registered(bytes4 signature, string method, address owner);
+
+  // constructor with self-registration
+  function SignatureReg() {
+    register('register(string)');
+    register('setOwner(address)');
+    register('drain()');
+  }
+
+  // registers a method mapping
+  function register(string _method) returns (bool) {
+    return _register(bytes4(sha3(_method)), _method);
+  }
+
+  // internal register function, signature => method
+  function _register(bytes4 _signature, string _method) internal when_unregistered(_signature) returns (bool) {
+    entries[_signature] = Entry(_method, msg.sender);
+    totalSignatures = totalSignatures + 1;
+    Registered(_signature, _method, msg.sender);
+    return true;
+  }
+
+  // returns a specific method
+  function get(bytes4 _signature) constant returns (string method, address owner) {
+    Entry entry = entries[_signature];
+    method = entry.method;
+    owner = entry.owner;
+  }
+
+  // in the case of any extra funds
+  function drain() only_owner {
+    if (!msg.sender.send(this.balance)) {
+      throw;
+    }
+  }
+}

--- a/SignatureReg.sol
+++ b/SignatureReg.sol
@@ -41,8 +41,8 @@ contract SignatureReg is Owned {
     _;
   }
 
-  // dispatched when a new signature => method is registered
-  event Registered(bytes4 signature, string method, address owner);
+  // dispatched when a new signature is registered
+  event Registered(address indexed owner, bytes4 signature, string method);
 
   // constructor with self-registration
   function SignatureReg() {
@@ -60,7 +60,7 @@ contract SignatureReg is Owned {
   function _register(bytes4 _signature, string _method) internal when_unregistered(_signature) returns (bool) {
     entries[_signature] = Entry(_method, msg.sender);
     totalSignatures = totalSignatures + 1;
-    Registered(_signature, _method, msg.sender);
+    Registered(msg.sender, _signature, _method);
     return true;
   }
 

--- a/SignatureReg.sol
+++ b/SignatureReg.sol
@@ -39,13 +39,11 @@ contract SignatureReg is Owned {
   }
 
   // dispatched when a new signature is registered
-  event Registered(address indexed owner, bytes4 signature, string method);
+  event Registered(address indexed owner, bytes4 indexed signature, string method);
 
   // constructor with self-registration
   function SignatureReg() {
     register('register(string)');
-    register('setOwner(address)');
-    register('drain()');
   }
 
   // registers a method mapping


### PR DESCRIPTION
A very simple registry that provides a mapping from “function(types)” to bytes4. To be used for lookups in the signer to determine what was called on contracts. 

With this in place and a simple “upload your ABI” dapp we can cater for any contracts with their ABIs registered for reverse lookups.

Signer would try a lookup here, if not found display what we currently have. If found, display the function call and decode the parameters based on the types inputted.

As a start, just having the ECR20 interface (possibly even as simple as just as only “transfer(address,uint256)”) registered, could already show us what type of transfers happens with tokens in the signer.

(This is along the same lines as the https://www.4bytes.directory, but not centralised and not under the whims of an unofficial org.)

4bytes.directory issue - https://github.com/ethcore/parity/issues/2208

Signer semantic analysis - https://github.com/ethcore/parity/issues/2280
