### PR TITLE
Remove unused parameter from reset function

### DIFF
--- a/DeadMansSwitch.sol
+++ b/DeadMansSwitch.sol
@@ -40,7 +40,7 @@ contract DeadMansSwitch {
         Reclaimed();
     }
 
-    function reset(address _backup) only_owner_or_backup {
+    function reset() only_owner_or_backup {
         timeout = 0;
         Reset();
     }


### PR DESCRIPTION
account _backup is never used and seems it will never be, as this contract support only a single backup account.