### PR TITLE
registry: add confirmReverseAs

### DIFF
--- a/SimpleRegistry.sol
+++ b/SimpleRegistry.sol
@@ -132,6 +132,12 @@ contract SimpleRegistry is Owned, MetadataRegistry, OwnerRegistry, ReverseRegist
 		return true;
 	}
 
+	function confirmReverseAs(string _name, address _who) when_proposed(_name) returns (bool success) {
+		reverses[_who] = _name;
+		ReverseConfirmed(_name, _who);
+		return true;
+	}
+
 	function removeReverse() {
 		ReverseRemoved(reverses[msg.sender], msg.sender);
 		delete entries[sha3(reverses[msg.sender])].reverse;

--- a/SimpleRegistry.sol
+++ b/SimpleRegistry.sol
@@ -132,7 +132,7 @@ contract SimpleRegistry is Owned, MetadataRegistry, OwnerRegistry, ReverseRegist
 		return true;
 	}
 
-	function confirmReverseAs(string _name, address _who) when_proposed(_name) returns (bool success) {
+	function confirmReverseAs(string _name, address _who) only_owner returns (bool success) {
 		reverses[_who] = _name;
 		ReverseConfirmed(_name, _who);
 		return true;


### PR DESCRIPTION
In order to be able to fully migrate reverse entries from the old registry, we need a way to confirm a proposed reverse for anyone. This PR adds a `confirmReverseAs(string _name, address _who)` next to the `confirmReverse(string _name)`.

afaict there is no other way than adding this method.