### PR TITLE
Wallet: Create operations; propagate OOGs.

### DIFF
--- a/Wallet.sol
+++ b/Wallet.sol
@@ -284,9 +284,9 @@ contract multisig {
     // Funds has arrived into the wallet (record how much).
     event Deposit(address _from, uint value);
     // Single transaction going out of the wallet (record who signed for it, how much, and to whom it's going).
-    event SingleTransact(address owner, uint value, address to, bytes data);
+    event SingleTransact(address owner, uint value, address to, bytes data, address created);
     // Multi-sig transaction going out of the wallet (record who signed for it last, the operation hash, how much, and to whom it's going).
-    event MultiTransact(address owner, bytes32 operation, uint value, address to, bytes data);
+    event MultiTransact(address owner, bytes32 operation, uint value, address to, bytes data, address created);
     // Confirmation still needed for a transaction.
     event ConfirmationNeeded(bytes32 operation, address initiator, uint value, address to, bytes data);
 
@@ -294,8 +294,8 @@ contract multisig {
 
     // TODO: document
     function changeOwner(address _from, address _to) external;
-    function execute(address _to, uint _value, bytes _data) external returns (bytes32);
-    function confirm(bytes32 _h) returns (bool);
+    function execute(address _to, uint _value, bytes _data) external returns (bytes32 o_hash);
+    function confirm(bytes32 _h) returns (bool o_success);
 }
 
 // usage:
@@ -336,31 +336,55 @@ contract Wallet is multisig, multiowned, daylimit {
     // If not, goes into multisig process. We provide a hash on return to allow the sender to provide
     // shortcuts for the other confirmations (allowing them to avoid replicating the _to, _value
     // and _data arguments). They still get the option of using them if they want, anyways.
-    function execute(address _to, uint _value, bytes _data) external onlyowner returns (bytes32 _r) {
+    function execute(address _to, uint _value, bytes _data) external onlyowner returns (bytes32 o_hash) {
         // first, take the opportunity to check that we're under the daily limit.
         if (_data.length == 0 && underLimit(_value)) {
-            SingleTransact(msg.sender, _value, _to, _data);
             // yes - just execute the call.
-            var _ = _to.call.value(_value)(_data);
-        }
-        // determine our operation hash.
-        _r = sha3(msg.data, block.number);
-        if (!confirm(_r) && m_txs[_r].to == 0) {
-            m_txs[_r].to = _to;
-            m_txs[_r].value = _value;
-            m_txs[_r].data = _data;
-            ConfirmationNeeded(_r, msg.sender, _value, _to, _data);
+			address created;
+			if (_to == 0) {
+				created = create(_value, _data);
+			} else {
+            	if (!_to.call.value(_value)(_data))
+					throw;
+			}
+			SingleTransact(msg.sender, _value, _to, _data, created);
+        } else {
+	        // determine our operation hash.
+	        o_hash = sha3(msg.data, block.number);
+			// do a confirmation if it's pre-existing
+			if (m_txs[o_hash].to != 0 || m_txs[o_hash].value != 0 || m_txs[o_hash].data.length != 0) {
+				confirm(o_hash);
+			} else {
+	            m_txs[o_hash].to = _to;
+	            m_txs[o_hash].value = _value;
+	            m_txs[o_hash].data = _data;
+	            ConfirmationNeeded(o_hash, msg.sender, _value, _to, _data);
+	        }
+		}
+    }
+
+	function create(uint _value, bytes _code) internal returns (address o_addr) {
+        assembly {
+            o_addr := create(_value, add(_code, 0x20), mload(_code))
+            jumpi(invalidJumpLabel, iszero(extcodesize(o_addr)))
         }
     }
 
     // confirm a transaction through just the hash. we use the previous transactions map, m_txs, in order
     // to determine the body of the transaction from the hash provided.
     function confirm(bytes32 _h) onlymanyowners(_h) returns (bool) {
-        if (m_txs[_h].to != 0) {
-            var _ = m_txs[_h].to.call.value(m_txs[_h].value)(m_txs[_h].data);
-            MultiTransact(msg.sender, _h, m_txs[_h].value, m_txs[_h].to, m_txs[_h].data);
+        if (m_txs[_h].to != 0 || m_txs[_h].value != 0 || m_txs[_h].data.length != 0) {
+			address created;
+			if (m_txs[_h].to == 0) {
+				created = create(m_txs[_h].value, m_txs[_h].data);
+			} else {
+	            if (!m_txs[_h].to.call.value(m_txs[_h].value)(m_txs[_h].data))
+					throw;
+			}
+
+            MultiTransact(msg.sender, _h, m_txs[_h].value, m_txs[_h].to, m_txs[_h].data, created);
             delete m_txs[_h];
-            return true;
+			return true;
         }
     }
 

--- a/Wallet.sol
+++ b/Wallet.sol
@@ -372,7 +372,7 @@ contract Wallet is multisig, multiowned, daylimit {
 
     // confirm a transaction through just the hash. we use the previous transactions map, m_txs, in order
     // to determine the body of the transaction from the hash provided.
-    function confirm(bytes32 _h) onlymanyowners(_h) returns (bool) {
+    function confirm(bytes32 _h) onlymanyowners(_h) returns (bool o_success) {
         if (m_txs[_h].to != 0 || m_txs[_h].value != 0 || m_txs[_h].data.length != 0) {
 			address created;
 			if (m_txs[_h].to == 0) {


### PR DESCRIPTION
Wallet can now handle create operations (set a zero `to` address). Should also propagate OOGs from the child call to the parent to ensure our `eth_estimateGas` works.